### PR TITLE
Small tweaks to Serilog configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This project makes use of entity framework code-first and a postgres SQL databas
 first there is a local docker compose file found in the `compose` directory.  This can be run from that directory with the following command:
 
 ```powershell
-docker-compose -f docker-compose-local.yml up
+docker-compose up
 ```
 **Note:** the postgres container needs environment variables in a `.env` file. There's an example in the project under `.env-dist`, but it's reccomended to change the username and password to something more secure.
 
@@ -27,7 +27,7 @@ This will run 4 containers.  These are as follows:
 
 #### RequestLogger Settings
 
-by default, the application is set to use settings from the `appsettings.Docker.json` app settings file.  If changes are made to this file after the containers are built, the command `docker-compose -f docker-compose-local.yml build` will need to be run from the `compose` folder.
+by default, the application is set to use settings from the `appsettings.Docker.json` app settings file.  If changes are made to this file after the containers are built, the command `docker-compose build` will need to be run from the `compose` folder.
 
 #### Entity Framework
 
@@ -39,4 +39,21 @@ Migrations can be added with the following commaand being run from the `src` dir
 
 ```powershell
 dotnet ef migrations add <migration name> -p .\Repository\ -s .\RequestLogger\
+```
+
+### Debugging
+
+There is a `docker-compose.local.yml` that can be used when debugging the RequestLogger app. 
+
+This will start all of the same resources as main `docker-compose.yml` with the following exceptions:
+
+* RequestLogger is _not_ ran
+* Nginx is using host port `:7020` (https port for RequestLogger) as mirror destination
+
+This allows RequestLogger to be run and save to Postgres instance running via compose. Any request to `http://localhost:8080/` will be mirrored to running RequestLogger instance.
+
+This can be ran via:
+
+```bash
+cd compose && docker compose -f docker-compose.local.yml up
 ```

--- a/compose/docker-compose.local.yml
+++ b/compose/docker-compose.local.yml
@@ -1,0 +1,44 @@
+version: '3'
+name: request-logger
+
+services:
+    web:
+        container_name: nginx
+        build:
+            context: ../nginx
+            dockerfile: nginx.Dockerfile
+        command: [nginx-debug, '-g', 'daemon off;']
+        ports:
+            - "8080:8080"
+        environment:
+            - EXTERNAL_PORT=8080
+            - NGINX_PROXY_PASS_MIRROR_LOCATION=https://host.docker.internal:7020
+            - NGINX_PROXY_PASS_LOCATION=http://mockserver:1080
+            - SERVICE=DLCS-local
+            - NGINX_RESOLVER=127.0.0.11
+                
+    mockserver:
+        image: mockserver/mockserver:latest
+        container_name: mock-server
+        environment:
+            MOCKSERVER_WATCH_INITIALIZATION_JSON: "true"
+            MOCKSERVER_PROPERTY_FILE: /config/mockserver.properties
+            MOCKSERVER_INITIALIZATION_JSON_PATH: /config/initializerJson.json
+        volumes:
+            - ../src/MockServerConfig/initializerJson.json:/config/initializerJson.json:ro
+        
+    postgres:
+        image: postgres:12.15
+        container_name: postgres
+        hostname: postgres
+        ports:
+            - "5452:5432"
+        volumes:
+            - rl_postgres_data:/var/lib/postgresql/data
+            - rl_postgres_data_backups:/backups
+        env_file:
+            - .env
+
+volumes:
+    rl_postgres_data: {}
+    rl_postgres_data_backups: {}

--- a/src/.dockerignore
+++ b/src/.dockerignore
@@ -23,3 +23,6 @@
 **/values.dev.yaml
 LICENSE
 README.md
+**/appsettings.Docker.json
+**/appsettings.Development.json
+**/Properties/launchSettings.json

--- a/src/RequestLogger/Program.cs
+++ b/src/RequestLogger/Program.cs
@@ -21,7 +21,11 @@ var logger = new LoggerConfiguration()
 
 Log.Logger = logger;
 
-builder.Logging.AddSerilog(logger);
+builder.Host.UseSerilog((hostContext, loggerConfiguration)
+    => loggerConfiguration
+        .ReadFrom.Configuration(hostContext.Configuration)
+        .Enrich.FromLogContext());
+
 builder.Services.AddHttpContextAccessor();
 builder.Services.AddControllers();
 
@@ -39,6 +43,7 @@ builder.Services.AddScoped<IRequestLoggerService, RequestLoggerService>();
 builder.Services.AddScoped<IBlacklistService, BlacklistService>();
 
 var app = builder.Build();
+app.UseSerilogRequestLogging();
 
 // Configure the HTTP request pipeline.
 if (app.Environment.IsDevelopment())

--- a/src/RequestLogger/appsettings.Development.json
+++ b/src/RequestLogger/appsettings.Development.json
@@ -1,8 +1,7 @@
 {
-  "Logging": {
-    "LogLevel": {
-      "Default": "Information",
-      "Microsoft.AspNetCore": "Warning"
+  "Serilog": {
+    "MinimumLevel": {
+      "Default": "Debug"
     }
   },
   "RequestLogger" : {

--- a/src/RequestLogger/appsettings.Docker.json
+++ b/src/RequestLogger/appsettings.Docker.json
@@ -1,8 +1,7 @@
 {
-  "Logging": {
-    "LogLevel": {
-      "Default": "Information",
-      "Microsoft.AspNetCore": "Warning"
+  "Serilog": {
+    "MinimumLevel": {
+      "Default": "Debug"
     }
   },
   "RequestLoggerSettings" : {

--- a/src/RequestLogger/appsettings.json
+++ b/src/RequestLogger/appsettings.json
@@ -1,8 +1,26 @@
 {
-  "Logging": {
-    "LogLevel": {
-      "Default": "Information",
-      "Microsoft.AspNetCore": "Warning"
+  "Serilog": {
+    "Using": [
+      "Serilog.Sinks.Console"
+    ],
+    "MinimumLevel": {
+      "Default": "Debug",
+      "Override": {
+        "Microsoft": "Warning",
+        "System": "Warning",
+        "HealthChecks": "Warning"
+      }
+    },
+    "WriteTo": [
+      {
+        "Name": "Console",
+        "Args": {
+          "outputTemplate": "[{Timestamp:HH:mm:ss} {Level:u3} {SourceContext}] {Message:lj}{NewLine}{Exception}"
+        }
+      }
+    ],
+    "Properties": {
+      "ApplicationName": "RequestLogger"
     }
   },
   "AllowedHosts": "*"


### PR DESCRIPTION
Slight change to serilog config, when deployed the default logging output was overly verbose with details of health-checks etc:
* Switched to `builder.Host.UseSerilog(` which gives more than `builder.Logging.AddSerilog(`.
* Reading serilog settings from appSettings (`.ReadFrom.Configuration(hostContext.Configuration)`) to allow changing levels without rebuilding.

Added local compose file to aid local debugging.